### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This library is generated from the AAD Graph API metadata using [Vipr] and [Vipr
 [Vipr-T4TemplateWriter]: https://github.com/msopentech/vipr-t4templatewriter
 [orc-for-ios]: https://github.com/msopentech/orc-for-ios
 
-[Using Cocoapods]: https://guides.cocoapods.org/using/using-cocoapods.html
+[Using CocoaPods]: https://guides.cocoapods.org/using/using-cocoapods.html
 [MSDN Add Common Consent]: https://msdn.microsoft.com/en-us/office/office365/howto/add-common-consent-manually
 
 ## Samples


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
